### PR TITLE
Enhance Sorting fixes

### DIFF
--- a/cypress/integration/tests/controls/tags/tagtype/sort.test.ts
+++ b/cypress/integration/tests/controls/tags/tagtype/sort.test.ts
@@ -68,7 +68,7 @@ describe("Tag type sort validations", function () {
 
         // Verify that the tag type rows are displayed in ascending order
         const afterAscSortList = getTableColumnData(rank);
-        verifySortAsc(afterAscSortList, unsortedList);
+        verifySortAsc(afterAscSortList, unsortedList, true);
 
         // Sort the tag type by rank in descending order
         sortDesc(rank);
@@ -76,7 +76,7 @@ describe("Tag type sort validations", function () {
 
         // Verify that the tag type rows are displayed in descending order
         const afterDescSortList = getTableColumnData(rank);
-        verifySortDesc(afterDescSortList, unsortedList);
+        verifySortDesc(afterDescSortList, unsortedList, true);
     });
 
     it("Tag count sort validations", function () {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -183,19 +183,27 @@ export function getTableColumnData(columnName: string): Array<string> {
     return itemList;
 }
 
-export function verifySortAsc(listToVerify: Array<any>, unsortedList: Array<any>): void {
+export function verifySortAsc(
+    listToVerify: Array<any>,
+    unsortedList: Array<any>,
+    isNumberic: boolean = false
+): void {
     cy.wrap(listToVerify).then((capturedList) => {
         var sortedList = unsortedList.sort((a, b) =>
-            a.toString().localeCompare(b, "en-us", { ignorePunctuation: true })
+            a.toString().localeCompare(b, "en-us", { ignorePunctuation: true, numeric: isNumberic })
         );
         expect(capturedList).to.be.deep.equal(sortedList);
     });
 }
 
-export function verifySortDesc(listToVerify: Array<any>, unsortedList: Array<any>): void {
+export function verifySortDesc(
+    listToVerify: Array<any>,
+    unsortedList: Array<any>,
+    isNumberic: boolean = false
+): void {
     cy.wrap(listToVerify).then((capturedList) => {
         var reverseSortedList = unsortedList.sort((a, b) =>
-            b.toString().localeCompare(a, "en-us", { ignorePunctuation: true })
+            b.toString().localeCompare(a, "en-us", { ignorePunctuation: true, numeric: isNumberic })
         );
         expect(capturedList).to.be.deep.equal(reverseSortedList);
     });

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -7,6 +7,7 @@ import {
     groupCount,
     memberCount,
     tagCount,
+    rank,
     tdTag,
     trTag,
     button,
@@ -171,7 +172,8 @@ export function getTableColumnData(columnName: string): Array<string> {
             if (
                 columnName === groupCount ||
                 columnName === memberCount ||
-                columnName === tagCount
+                columnName === tagCount ||
+                columnName === rank
             ) {
                 if ($ele.text() !== "") itemList.push(Number($ele.text()));
             } else {


### PR DESCRIPTION
Changes:
### First change
Added the "Rank" column to the set of predefined Number columns. This is the exact change: https://github.com/carlosthe19916/tackle-ui-tests/blob/e4fc89091de65e9c67d7cd423b440c92bd4a4e24/cypress/utils/utils.ts#L176

Before:
```
if (
                columnName === groupCount ||
                columnName === memberCount ||
                columnName === tagCount
            ) {
```

After:
```
if (
                columnName === groupCount ||
                columnName === memberCount ||
                columnName === tagCount ||
                columnName === rank
            ) {
```

With this change, we ensure we get Numeric values from the table rather than String values.

### Second change
`localeCompare` seems to compare values assuming they are String by default. For instance;
```
[1, 2, 4, 5, 6, 16, 18, 21].sort((a, b) => a.toString().localeCompare(b, "en-us"))

Result:
--------
(8) [1, 16, 18, 2, 21, 4, 5, 6]
```

As you can see from the example above, the sorting result is incorrect. In order to make it work we need to add properties:
```
{ ignorePunctuation: true, numeric: true }
```

I suggest changing the definition of the function `verifySortAsc` and `verifySortDesc` so it receives an additional param named `isNumberic: boolean` so we can add it to the `localCompareFunction`

```
export function verifySortAsc(listToVerify: Array<any>, unsortedList: Array<any>, isNumberic: boolean = false): void {
    cy.wrap(listToVerify).then((capturedList) => {
        var sortedList = unsortedList.sort((a, b) =>
            a.toString().localeCompare(b, "en-us", { ignorePunctuation: true, numeric: isNumberic })
        );
        expect(capturedList).to.be.deep.equal(sortedList);
    });
}
```
Note: I've discovered the problem with this data:
![Screenshot from 2021-08-06 10-06-12](https://user-images.githubusercontent.com/2582866/128483087-347d0579-46b5-4540-9308-6338511d733e.png)
